### PR TITLE
Enable watchdog in bootloader

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -29,6 +29,10 @@ int main()
 {
     System sys;
 
+    if (ENABLE_WATCHDOG) {
+        sys.enableWatchdog();
+    }
+
     Bootloader bl;
     bl.boot(sys);
 }

--- a/src/Config.h
+++ b/src/Config.h
@@ -48,3 +48,10 @@ struct BootloaderStatus {
     uint32_t liveAppSelect;
     uint32_t retryCount;
 };
+
+/*
+ * Enables the watchdog for the MCU. The actual implementation details,
+ * as well as the value for the watchdog counter are platform dependent
+ * and can be configured in the according System_*.cpp file.
+ */
+const bool ENABLE_WATCHDOG = true;

--- a/src/System.h
+++ b/src/System.h
@@ -30,8 +30,8 @@
 
 class System
 {
-public:
-     /**
+  public:
+    /**
      * @brief read the status from flash
      *
      * @param status struct to read the status into
@@ -51,4 +51,9 @@ public:
      * @param bootAddress absolute memory address of the binary to execute
      */
     void executeFromAddress(uint32_t bootAddress);
+
+    /**
+     * @brief enables the MCU's watchdog.
+     */
+    void enableWatchdog();
 };

--- a/src/System_native.cpp
+++ b/src/System_native.cpp
@@ -29,12 +29,8 @@ void System::readStatusReg(BootloaderStatus& status)
     status = { 0 };
 }
 
-void System::writeStatusReg(BootloaderStatus& status)
-{
+void System::writeStatusReg(BootloaderStatus& status) {}
 
-}
+void System::executeFromAddress(uint32_t bootAddress) {}
 
-void System::executeFromAddress(uint32_t bootAddress)
-{
-
-}
+void System::enableWatchdog() {}

--- a/src/System_stm32f1.cpp
+++ b/src/System_stm32f1.cpp
@@ -25,6 +25,12 @@
 #include "System.h"
 #include "stm32f1xx.h"
 
+// Watchdog clock frequency is ~40kHz, divide clock by 64
+static const uint32_t WATCHDOG_PRESCALER = 0b100;
+
+// Watchdog timeout of 5 seconds
+static const uint32_t WATCHDOG_COUNTER = 3125;
+
 /* application entry point */
 typedef void (*AppEntry)(void);
 
@@ -104,4 +110,14 @@ void System::executeFromAddress(uint32_t bootAddress)
 
     /* Should never reach here. */
     __NOP();
+}
+
+void System::enableWatchdog()
+{
+    WRITE_REG(IWDG->KR, 0x5555);               // Disable write protection of IWDG registers
+    WRITE_REG(IWDG->PR, WATCHDOG_PRESCALER);   // Clock frequency is ~40kHz, divide clock by 64
+    WRITE_REG(IWDG->RLR, WATCHDOG_COUNTER);    // Watchdog timeout of 5 seconds
+    WRITE_REG(IWDG->KR, 0xAAAA);               // Reload IWDG
+    WRITE_REG(IWDG->KR, 0xCCCC);               // Start IWDG
+    WRITE_REG(IWDG->KR, 0xAAAA);               // Kick IWDG
 }


### PR DESCRIPTION
If the new app does not boot after an OTA, the bootloader
will now automatically try again after 5 seconds.